### PR TITLE
Remove fontawesome from covmap

### DIFF
--- a/covmap/src/d3chartcovmap.js
+++ b/covmap/src/d3chartcovmap.js
@@ -5,8 +5,7 @@
 		hasURLSearchParams = window.URLSearchParams,
 		isTouchScreenOnly = (window.matchMedia("(pointer: coarse)").matches && !window.matchMedia("(any-pointer: fine)").matches),
 		isBookmarkPage = window.location.hostname + window.location.pathname === "pfbi.unocha.org/bookmark.html",
-		fontAwesomeLink = "https://use.fontawesome.com/releases/v5.6.3/css/all.css",
-		cssLinks = ["https://cbpfgms.github.io/css/d3chartstyles.css", "https://cbpfgms.github.io/css/d3chartstylescovmap.css", fontAwesomeLink],
+		cssLinks = ["https://cbpfgms.github.io/css/d3chartstyles.css", "https://cbpfgms.github.io/css/d3chartstylescovmap.css"],
 		d3URL = "https://cdnjs.cloudflare.com/ajax/libs/d3/5.15.0/d3.min.js",
 		topoJsonUrl = "https://cdnjs.cloudflare.com/ajax/libs/topojson/3.0.2/topojson.min.js",
 		html2ToCanvas = "https://cbpfgms.github.io/libraries/html2canvas.min.js",
@@ -22,10 +21,6 @@
 			externalCSS.setAttribute("rel", "stylesheet");
 			externalCSS.setAttribute("type", "text/css");
 			externalCSS.setAttribute("href", cssLink);
-			if (cssLink === fontAwesomeLink) {
-				externalCSS.setAttribute("integrity", "sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/");
-				externalCSS.setAttribute("crossorigin", "anonymous")
-			};
 			document.getElementsByTagName("head")[0].appendChild(externalCSS);
 		};
 


### PR DESCRIPTION
This map is embedded in https://www.unocha.org/our-work/humanitarian-financing, where we discovered the 'social' buttons are going blank as they use a different version of fontawesome, which gets overwritten by the version in the map.

I had a quick look and don't *think* I see fontawesome is used in the map, so the simple answer is to remove it. Can you confirm that this is the case?

Thanks!